### PR TITLE
Negative values in screen message

### DIFF
--- a/Source/PadHeap.cs
+++ b/Source/PadHeap.cs
@@ -139,8 +139,8 @@ namespace HeapPadder
                 GC.Collect();
                 curMem = GC.GetTotalMemory(false);
                 Log.Info("After final collect, memory = " + (curMem / 1024) + " KB");
-                ScreenMessages.PostScreenMessage("HeapPadder, initial mem: " + ((int)startMem / 1024).ToString("F0") +
-                    ", minMem: " + ((int)minMem / 1024).ToString("F0") + ", final mem: " + ((int)curMem / 1024).ToString("F0"), 10f, ScreenMessageStyle.UPPER_CENTER);
+                ScreenMessages.PostScreenMessage("HeapPadder, initial mem: " + (startMem / 1024).ToString("F0") +
+                    ", minMem: " + (minMem / 1024).ToString("F0") + ", final mem: " + (curMem / 1024).ToString("F0"), 10f, ScreenMessageStyle.UPPER_CENTER);
 
             }
             catch (Exception e)

--- a/Source/PadHeap.cs
+++ b/Source/PadHeap.cs
@@ -152,12 +152,13 @@ namespace HeapPadder
         int GetMem()
         {
             var si = SystemInfo.systemMemorySize;
-            Log.Info("Physical RAM (bytes): " + si.ToString());
+            Log.Info("Physical RAM (MB): " + si.ToString());
             int m = si / 1024;
             ScreenMessages.PostScreenMessage("HeapPadder, System Memory Size: " + m + " gig", 10f, ScreenMessageStyle.UPPER_CENTER);
-            return (int)m;
+            return m;
 
         }
+
         void UpdateFromConfig()
         {
             for (int i = 0; i < counts.Length; i++)


### PR DESCRIPTION
A type cast in the screen message displayed negative values:
![intpad](https://user-images.githubusercontent.com/758097/93714855-a5ca7900-fb65-11ea-8971-03f02be7990e.png)

This simply removes the cast:
![intpad2](https://user-images.githubusercontent.com/758097/93714854-a531e280-fb65-11ea-9715-2325975d1534.png)

Additionally, a log message change from bytes to MB.